### PR TITLE
Definition file for TypeScript

### DIFF
--- a/lib/slidedown.d.ts
+++ b/lib/slidedown.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="react" />
+
+declare module 'react-slidedown' {
+  import { ReactChild, Component } from 'react';
+
+  type SlideDownProps = {
+      transitionOnAppear?: boolean,
+      closed?: boolean
+  };
+
+  interface SlideDownNode extends Component<SlideDownProps> { }
+
+  export function SlideDown(props: SlideDownProps): SlideDownNode;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "Component for animating height during mount/unmount using a CSS transition",
   "main": "lib/slidedown.js",
+  "types": "lib/slidedown.d.ts",
   "style": "lib/slidedown.css",
   "scripts": {
     "test": "npm run build && karma start --single-run",


### PR DESCRIPTION
I have tested this with our application and it works fine. I thought it would be better to send you a pull request to add this definition file in the react-slidedown npm package itself, rather than adding it to DefinitelyTyped. Please let me know if you think I need to make any improvements.