### PR TITLE
support 'as' props

### DIFF
--- a/lib/slidedown.tsx
+++ b/lib/slidedown.tsx
@@ -122,22 +122,24 @@ class SlideDownContent extends Component<SlideDownContentProps, SlideDownContent
     }
 
     render() {
-        const { children, className, closed, transitionOnAppear, forwardedRef, ...rest } = this.props
+        const { as = 'div', children, className, closed, transitionOnAppear, forwardedRef, ...rest } = this.props
         const containerClassName = className ? 'react-slidedown ' + className : 'react-slidedown'
 
-        return (
-            <div
-                ref={this.handleRef}
-                className={containerClassName}
-                onTransitionEnd={this.handleTransitionEnd}
-                {...rest}>
-                {this.state.children}
-            </div>
-        )
+        return React.createElement(
+            as,
+            {
+                ref: this.handleRef,
+                className: containerClassName,
+                onTransitionEnd: this.handleTransitionEnd,
+                ...rest
+            },
+            this.state.children
+        );
     }
 }
 
 interface SlideDownProps extends React.HTMLAttributes<HTMLDivElement> {
+    as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
     closed?: boolean
     transitionOnAppear?: boolean
 }


### PR DESCRIPTION
When I tried to use it inside the 'tr' tag, the Chrome console warned me that it wasn't a 'td' tag.
I'm using fork in a hurry, but I hope this library supports 'as'.

Thanks.
