### PR TITLE
Make all classnames overwritable

### DIFF
--- a/lib/slidedown.tsx
+++ b/lib/slidedown.tsx
@@ -46,7 +46,7 @@ class SlideDownContent extends Component<SlideDownContentProps, SlideDownContent
     componentDidMount() {
         if (this.outerRef) {
             if (this.props.closed || !this.props.children) {
-                this.outerRef.classList.add('closed')
+                this.outerRef.classList.add(this.closedClassName)
                 this.outerRef.style.height = '0px'
             } else if (this.props.transitionOnAppear) {
                 this.startTransition('0px')
@@ -93,7 +93,7 @@ class SlideDownContent extends Component<SlideDownContentProps, SlideDownContent
         }
 
         if (parseFloat(endHeight).toFixed(2) !== parseFloat(prevHeight).toFixed(2)) {
-            this.outerRef.classList.add('transitioning')
+            this.outerRef.classList.add(this.transitioningClassName)
             this.outerRef.style.height = prevHeight
             this.outerRef.offsetHeight // force repaint
             this.outerRef.style.transitionProperty = 'height'
@@ -122,8 +122,10 @@ class SlideDownContent extends Component<SlideDownContentProps, SlideDownContent
     }
 
     render() {
-        const { as = 'div', children, className, closed, transitionOnAppear, forwardedRef, ...rest } = this.props
-        const containerClassName = className ? 'react-slidedown ' + className : 'react-slidedown'
+        const { as = 'div', children, className, transitioningClassName, closedClassName, closed, transitionOnAppear, forwardedRef, ...rest } = this.props
+        const containerClassName = className ? className : 'react-slidedown';
+        this.transitioningClassName = transitioningClassName ? transitioningClassName : 'transitioning';
+        this.closedClassName = closedClassName ? closedClassName : 'closed';
 
         return React.createElement(
             as,


### PR DESCRIPTION
Since I am using [BEM](http://getbem.com/) in my project,  I am required to overwrite all the classnames defined in `SlideDown`. So I added these two new props:

```jsx
import 'mything.css'

<SlideDown
  className='myting'
  transitioningClassName='myting--transitioning'
  closedClassName='myting--closed'
  closed={isMyThingClosed?}
>
```

If ommited everything behaves as it did.