### PR TITLE
Update react & react-dom peer-dep to support 17.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^16.3.0 || 17",
+    "react-dom": "^16.3.0 || 17"
   },
   "files": [
     "lib/**/*.js",


### PR DESCRIPTION
I'm using the library in a react 17.x project and works perfectly, however the npm install shows the breaking dependency warning:

`npm WARN react-slidedown@2.4.5 requires a peer of react@^16.3.0 but none is installed. You must install peer dependencies yourself.`

Thanks for the help!